### PR TITLE
Changed webpack-dev-server version, due to security issues found in v…

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -37,6 +37,6 @@
     "url-loader": "1.0.1",
     "webpack": "4.18.0",
     "webpack-cli": "3.1.0",
-    "webpack-dev-server": "3.1.8"
+    "webpack-dev-server": "3.1.14"
   }
 }


### PR DESCRIPTION
Upped webpack-dev-server version due to security issue ( low severity ) in the lib. The problem is resolved in 3.1.11, but going to the latest version seems like the best move.