### PR TITLE
added verification of the jwt token

### DIFF
--- a/impl/config-example.yml
+++ b/impl/config-example.yml
@@ -17,6 +17,11 @@ slack:
   botUserToken: <your-slack-app-bot-user-token>
   apiToken: <your-slack-app-api-token>
 
+openId:
+  issuer: https://accounts.google.com
+  jwksUri: https://www.googleapis.com/oauth2/v3/certs
+  clientId: <client-id-found-in-google-console-for-example>
+
 logging:
   # Log requests to file, other level INFO to redis (kibana)
   additivity:

--- a/impl/config.yml
+++ b/impl/config.yml
@@ -10,3 +10,8 @@ database:
 
 applicationTokenConfig:
   secret: a-valid-but-not-secure-secret
+
+openId:
+  issuer: https://accounts.google.com
+  jwksUri: https://www.googleapis.com/oauth2/v3/certs
+  clientId: client-id-found-in-google-console-for-example

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -27,7 +27,11 @@
             <artifactId>jslack</artifactId>
             <version>1.1.7</version>
         </dependency>
-
+        <dependency>
+            <groupId>com.auth0</groupId>
+            <artifactId>jwks-rsa</artifactId>
+            <version>0.7.0</version>
+        </dependency>
         <dependency>
             <groupId>javax.websocket</groupId>
             <artifactId>javax.websocket-api</artifactId>

--- a/impl/src/main/java/auth/ApplicationTokenVerifier.java
+++ b/impl/src/main/java/auth/ApplicationTokenVerifier.java
@@ -6,6 +6,7 @@ import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.Clock;
 import com.auth0.jwt.interfaces.DecodedJWT;
+import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
 /**
@@ -24,6 +25,7 @@ public class ApplicationTokenVerifier {
 		// used by guice
 	}
 
+	@Inject
 	public ApplicationTokenVerifier(ClockProvider clockProvider, ApplicationTokenConfig applicationTokenConfig) {
 		Algorithm algorithm = Algorithm.HMAC256(applicationTokenConfig.getSecret());
 		JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification)JWT.require(algorithm)

--- a/impl/src/main/java/auth/ClockProviderImpl.java
+++ b/impl/src/main/java/auth/ClockProviderImpl.java
@@ -1,6 +1,7 @@
 package auth;
 
 import com.auth0.jwt.interfaces.Clock;
+import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
 import java.util.Date;
@@ -11,6 +12,7 @@ import java.util.Date;
 @Singleton
 public class ClockProviderImpl implements ClockProvider {
 
+    @Inject
     public ClockProviderImpl() {
         // used by guice
     }

--- a/impl/src/main/java/auth/Jwk.java
+++ b/impl/src/main/java/auth/Jwk.java
@@ -1,140 +1,133 @@
 package auth;
 
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class Jwk {
 
-    private String kid;
-    private String kty;
-    private String e;
-    private String n;
+    @JsonProperty("kid")
+    private String id;
+    @JsonProperty("kty")
+    private String type;
+    @JsonProperty("alg")
+    private String algorithm;
+    @JsonProperty("use")
+    private String usage;
+    @JsonProperty("key_ops")
+    private List<String> operations;
+    @JsonProperty("x5u")
+    private String certificateUrl;
+    @JsonProperty("x5c")
+    private List<String> certificateChain;
+    @JsonProperty("x5t")
+    private String certificateThumbprint;
 
-    private String alg;
-    private String use;
-    private List<String> key_ops;
-    private String x5u;
-    private List<String> x5c;
-    private String x5t;
     private Map<String, Object> additionalAttributes = new HashMap<>();
 
     public Jwk() {
-
+        // used by jackson
     }
 
     /**
      * @return id
      */
-    public String getKid() {
-        return kid;
+    public String getId() {
+        return id;
     }
 
-    public void setKid(String kid) {
-        this.kid = kid;
+    public void setId(String id) {
+        this.id = id;
     }
 
     /**
      * @return type
      */
-    public String getKty() {
-        return kty;
+    public String getType() {
+        return type;
     }
 
-    public void setKty(String kty) {
-        this.kty = kty;
+    public void setType(String type) {
+        this.type = type;
     }
 
     /**
      * @return algorithm
      */
-    public String getAlg() {
-        return alg;
+    public String getAlgorithm() {
+        return algorithm;
     }
 
-    public void setAlg(String alg) {
-        this.alg = alg;
+    public void setAlgorithm(String algorithm) {
+        this.algorithm = algorithm;
     }
 
     /**
      * @return usage
      */
-    public String getUse() {
-        return use;
+    public String getUsage() {
+        return usage;
     }
 
-    public void setUse(String use) {
-        this.use = use;
+    public void setUsage(String usage) {
+        this.usage = usage;
     }
 
     /**
      * @return operations
      */
-    public List<String> getKey_ops() {
-        return key_ops;
+    public List<String> getOperations() {
+        return operations;
     }
 
-    public void setKey_ops(List<String> key_ops) {
-        this.key_ops = key_ops;
+    public void setOperations(List<String> operations) {
+        this.operations = operations;
     }
 
     /**
-     * @return x5u
+     * @return certificateUrl
      */
-    public String getX5u() {
-        return x5u;
+    public String getCertificateUrl() {
+        return certificateUrl;
     }
 
-    public void setX5u(String x5u) {
-        this.x5u = x5u;
+    public void setCertificateUrl(String certificateUrl) {
+        this.certificateUrl = certificateUrl;
     }
 
     /**
      * @return certificateChain
      */
-    public List<String> getX5c() {
-        return x5c;
+    public List<String> getCertificateChain() {
+        return certificateChain;
     }
 
-    public void setX5c(List<String> x5c) {
-        this.x5c = x5c;
+    public void setCertificateChain(List<String> certificateChain) {
+        this.certificateChain = certificateChain;
     }
 
     /**
      * @return certificateThumbprint
      */
-    public String getX5t() {
-        return x5t;
+    public String getCertificateThumbprint() {
+        return certificateThumbprint;
     }
 
-    public void setX5t(String x5t) {
-        this.x5t = x5t;
+    public void setCertificateThumbprint(String certificateThumbprint) {
+        this.certificateThumbprint = certificateThumbprint;
     }
 
-    public String getE() {
-        return e;
-    }
-
-    public void setE(String e) {
-        additionalAttributes.put("e", e);
-        this.e = e;
-    }
-
-    public String getN() {
-        return n;
-    }
-
-    public void setN(String n) {
-        additionalAttributes.put("n", n);
-        this.n = n;
-    }
 
     public Map<String, Object> getAdditionalAttributes() {
         return additionalAttributes;
     }
 
-    public void setAdditionalAttributes(Map<String, Object> additionalAttributes) {
-        // this.additionalAttributes = additionalAttributes;
+    @JsonAnySetter
+    public void setAdditionalAttributes(String key, String value) {
+        this.additionalAttributes.put(key, value);
     }
 
 }

--- a/impl/src/main/java/auth/Jwk.java
+++ b/impl/src/main/java/auth/Jwk.java
@@ -1,0 +1,140 @@
+package auth;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Jwk {
+
+    private String kid;
+    private String kty;
+    private String e;
+    private String n;
+
+    private String alg;
+    private String use;
+    private List<String> key_ops;
+    private String x5u;
+    private List<String> x5c;
+    private String x5t;
+    private Map<String, Object> additionalAttributes = new HashMap<>();
+
+    public Jwk() {
+
+    }
+
+    /**
+     * @return id
+     */
+    public String getKid() {
+        return kid;
+    }
+
+    public void setKid(String kid) {
+        this.kid = kid;
+    }
+
+    /**
+     * @return type
+     */
+    public String getKty() {
+        return kty;
+    }
+
+    public void setKty(String kty) {
+        this.kty = kty;
+    }
+
+    /**
+     * @return algorithm
+     */
+    public String getAlg() {
+        return alg;
+    }
+
+    public void setAlg(String alg) {
+        this.alg = alg;
+    }
+
+    /**
+     * @return usage
+     */
+    public String getUse() {
+        return use;
+    }
+
+    public void setUse(String use) {
+        this.use = use;
+    }
+
+    /**
+     * @return operations
+     */
+    public List<String> getKey_ops() {
+        return key_ops;
+    }
+
+    public void setKey_ops(List<String> key_ops) {
+        this.key_ops = key_ops;
+    }
+
+    /**
+     * @return x5u
+     */
+    public String getX5u() {
+        return x5u;
+    }
+
+    public void setX5u(String x5u) {
+        this.x5u = x5u;
+    }
+
+    /**
+     * @return certificateChain
+     */
+    public List<String> getX5c() {
+        return x5c;
+    }
+
+    public void setX5c(List<String> x5c) {
+        this.x5c = x5c;
+    }
+
+    /**
+     * @return certificateThumbprint
+     */
+    public String getX5t() {
+        return x5t;
+    }
+
+    public void setX5t(String x5t) {
+        this.x5t = x5t;
+    }
+
+    public String getE() {
+        return e;
+    }
+
+    public void setE(String e) {
+        additionalAttributes.put("e", e);
+        this.e = e;
+    }
+
+    public String getN() {
+        return n;
+    }
+
+    public void setN(String n) {
+        additionalAttributes.put("n", n);
+        this.n = n;
+    }
+
+    public Map<String, Object> getAdditionalAttributes() {
+        return additionalAttributes;
+    }
+
+    public void setAdditionalAttributes(Map<String, Object> additionalAttributes) {
+        // this.additionalAttributes = additionalAttributes;
+    }
+
+}

--- a/impl/src/main/java/auth/Jwk.java
+++ b/impl/src/main/java/auth/Jwk.java
@@ -32,9 +32,6 @@ public class Jwk {
         // used by jackson
     }
 
-    /**
-     * @return id
-     */
     public String getId() {
         return id;
     }
@@ -43,9 +40,6 @@ public class Jwk {
         this.id = id;
     }
 
-    /**
-     * @return type
-     */
     public String getType() {
         return type;
     }
@@ -54,9 +48,6 @@ public class Jwk {
         this.type = type;
     }
 
-    /**
-     * @return algorithm
-     */
     public String getAlgorithm() {
         return algorithm;
     }
@@ -65,9 +56,6 @@ public class Jwk {
         this.algorithm = algorithm;
     }
 
-    /**
-     * @return usage
-     */
     public String getUsage() {
         return usage;
     }
@@ -76,9 +64,6 @@ public class Jwk {
         this.usage = usage;
     }
 
-    /**
-     * @return operations
-     */
     public List<String> getOperations() {
         return operations;
     }
@@ -87,9 +72,6 @@ public class Jwk {
         this.operations = operations;
     }
 
-    /**
-     * @return certificateUrl
-     */
     public String getCertificateUrl() {
         return certificateUrl;
     }
@@ -98,9 +80,6 @@ public class Jwk {
         this.certificateUrl = certificateUrl;
     }
 
-    /**
-     * @return certificateChain
-     */
     public List<String> getCertificateChain() {
         return certificateChain;
     }
@@ -109,9 +88,6 @@ public class Jwk {
         this.certificateChain = certificateChain;
     }
 
-    /**
-     * @return certificateThumbprint
-     */
     public String getCertificateThumbprint() {
         return certificateThumbprint;
     }

--- a/impl/src/main/java/auth/JwkResource.java
+++ b/impl/src/main/java/auth/JwkResource.java
@@ -5,7 +5,7 @@ import rx.Observable;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
-@Path("")
+@Path(value = "not-used")
 public interface JwkResource {
 
     @GET

--- a/impl/src/main/java/auth/JwkResource.java
+++ b/impl/src/main/java/auth/JwkResource.java
@@ -1,0 +1,14 @@
+package auth;
+
+import rx.Observable;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("")
+public interface JwkResource {
+
+    @GET
+    Observable<JwkResponse> getJWks();
+
+}

--- a/impl/src/main/java/auth/JwkResourceAutoBindModule.java
+++ b/impl/src/main/java/auth/JwkResourceAutoBindModule.java
@@ -1,0 +1,15 @@
+package auth;
+
+import com.google.inject.Binder;
+import com.google.inject.Singleton;
+import se.fortnox.reactivewizard.binding.AutoBindModule;
+
+public class JwkResourceAutoBindModule implements AutoBindModule {
+
+    @Override
+    public void configure(Binder binder) {
+        binder.bind(JwkResource.class).toProvider(JwkResourceProvider.class)
+                .in(Singleton.class);
+    }
+
+}

--- a/impl/src/main/java/auth/JwkResourceProvider.java
+++ b/impl/src/main/java/auth/JwkResourceProvider.java
@@ -1,0 +1,27 @@
+package auth;
+
+
+import auth.openid.OpenIdConfiguration;
+import se.fortnox.reactivewizard.client.HttpClient;
+import se.fortnox.reactivewizard.client.HttpClientConfig;
+import se.fortnox.reactivewizard.client.HttpClientProvider;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import java.net.URISyntaxException;
+
+public class JwkResourceProvider implements Provider<JwkResource> {
+    private final JwkResource jwkResource;
+
+    @Inject
+    public JwkResourceProvider(HttpClientProvider httpClientProvider, OpenIdConfiguration openIdConfiguration) throws URISyntaxException {
+        HttpClientConfig httpClientConfig = new HttpClientConfig(openIdConfiguration.getJwksUri());
+        HttpClient client = httpClientProvider.createClient(httpClientConfig);
+        jwkResource = client.create(JwkResource.class);
+    }
+
+    @Override
+    public JwkResource get() {
+        return jwkResource;
+    }
+}

--- a/impl/src/main/java/auth/JwkResourceProvider.java
+++ b/impl/src/main/java/auth/JwkResourceProvider.java
@@ -2,26 +2,50 @@ package auth;
 
 
 import auth.openid.OpenIdConfiguration;
+import com.google.common.annotations.VisibleForTesting;
 import se.fortnox.reactivewizard.client.HttpClient;
 import se.fortnox.reactivewizard.client.HttpClientConfig;
-import se.fortnox.reactivewizard.client.HttpClientProvider;
+import se.fortnox.reactivewizard.jaxrs.JaxRsMeta;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
+import java.lang.reflect.Method;
+import java.net.URI;
 import java.net.URISyntaxException;
 
 public class JwkResourceProvider implements Provider<JwkResource> {
     private final JwkResource jwkResource;
 
     @Inject
-    public JwkResourceProvider(HttpClientProvider httpClientProvider, OpenIdConfiguration openIdConfiguration) throws URISyntaxException {
+    public JwkResourceProvider(OpenIdConfiguration openIdConfiguration) throws URISyntaxException {
         HttpClientConfig httpClientConfig = new HttpClientConfig(openIdConfiguration.getJwksUri());
-        HttpClient client = httpClientProvider.createClient(httpClientConfig);
+        URI uri = new URI(openIdConfiguration.getJwksUri());
+        HttpClient client = getHttpClient(httpClientConfig, uri);
         jwkResource = client.create(JwkResource.class);
+
     }
 
     @Override
     public JwkResource get() {
         return jwkResource;
+    }
+
+    @VisibleForTesting
+    HttpClient getHttpClient(HttpClientConfig httpClientConfig, URI uri) {
+        return new HttpClientWithHardCodedPath(httpClientConfig, uri);
+    }
+
+    class HttpClientWithHardCodedPath extends HttpClient {
+        private final String path;
+
+        HttpClientWithHardCodedPath(HttpClientConfig config, URI uri) {
+            super(config);
+            path = uri.getPath();
+        }
+
+        @Override
+        protected String getPath(Method method, Object[] arguments, JaxRsMeta meta) {
+            return path;
+        }
     }
 }

--- a/impl/src/main/java/auth/JwkResponse.java
+++ b/impl/src/main/java/auth/JwkResponse.java
@@ -2,23 +2,10 @@ package auth;
 
 import java.util.List;
 
-/**
- * Represents a response from a JWk endpoint.
- * <p>
- * Meaning of the parameters returned:
- * id                    kid
- * type                  kyt
- * algorithm             alg
- * usage                 use
- * operations            key_ops
- * certificateUrl        x5u
- * certificateChain      x5c
- * certificateThumbprint x5t
- * additionalAttributes  additional attributes not part of the standard ones
- */
 public class JwkResponse {
 
     public JwkResponse() {
+        // used by jackson
     }
 
     private List<Jwk> keys;

--- a/impl/src/main/java/auth/JwkResponse.java
+++ b/impl/src/main/java/auth/JwkResponse.java
@@ -1,0 +1,36 @@
+package auth;
+
+import java.util.List;
+
+/**
+ * Represents a response from a JWk endpoint.
+ * <p>
+ * Meaning of the parameters returned:
+ * id                    kid
+ * type                  kyt
+ * algorithm             alg
+ * usage                 use
+ * operations            key_ops
+ * certificateUrl        x5u
+ * certificateChain      x5c
+ * certificateThumbprint x5t
+ * additionalAttributes  additional attributes not part of the standard ones
+ */
+public class JwkResponse {
+
+    public JwkResponse() {
+    }
+
+    private List<Jwk> keys;
+
+
+    public List<Jwk> getKeys() {
+        return keys;
+    }
+
+    public void setKeys(List<Jwk> keys) {
+        this.keys = keys;
+    }
+
+
+}

--- a/impl/src/main/java/auth/openid/OpenIdConfiguration.java
+++ b/impl/src/main/java/auth/openid/OpenIdConfiguration.java
@@ -1,0 +1,60 @@
+package auth.openid;
+
+import se.fortnox.reactivewizard.config.Config;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * Get issue, jwksUri from:
+ * https://accounts.google.com/.well-known/risc-configuration
+ * Get your apps' client ID and private key from the API console:
+ * https://console.developers.google.com/apis/credentials?project=_
+ */
+@Config("openId")
+public class OpenIdConfiguration {
+
+
+    @NotNull
+    private String issuer;
+
+    @NotNull
+    private String jwksUri;
+
+    @NotNull
+    private String clientId;
+
+    @NotNull
+    private String privateKey;
+
+    public String getIssuer() {
+        return issuer;
+    }
+
+    public void setIssuer(String issuer) {
+        this.issuer = issuer;
+    }
+
+    public String getJwksUri() {
+        return jwksUri;
+    }
+
+    public void setJwksUri(String jwksUri) {
+        this.jwksUri = jwksUri;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getPrivateKey() {
+        return privateKey;
+    }
+
+    public void setPrivateKey(String privateKey) {
+        this.privateKey = privateKey;
+    }
+}

--- a/impl/src/main/java/auth/openid/OpenIdValidator.java
+++ b/impl/src/main/java/auth/openid/OpenIdValidator.java
@@ -80,16 +80,15 @@ public class OpenIdValidator {
      */
     private Observable<DecodedJWT> verify(String token) {
         final String issuer = openIdConfiguration.getIssuer();
-        final DecodedJWT unverifiedJwt = JWT.decode(token);
-        final String keyId = unverifiedJwt.getKeyId();
+        final String keyId = JWT.decode(token).getKeyId();
         return jwkResource.getJWks()
-                .doOnError((e) -> LOG.error("failed to get jwks to verify token", e))
+                .doOnError(e -> LOG.error("failed to get jwks to verify token", e))
                 .map(OpenIdValidator::getJwksOrderedById)
-                .doOnError((e) -> LOG.error("failed to order jwks", e))
+                .doOnError(e -> LOG.error("failed to order jwks", e))
                 .flatMap(jwksById -> getPublicKeyByKeyId(keyId, jwksById))
-                .doOnError((e) -> LOG.info("failed to get jwk by kid", e))
+                .doOnError(e -> LOG.info("failed to get jwk by kid", e))
                 .map(publicKey -> getJwtVerifier(issuer, publicKey))
-                .doOnError((e) -> LOG.info("failed to create jwt verifier", e))
+                .doOnError(e -> LOG.info("failed to create jwt verifier", e))
                 .map(jwtVerifier -> jwtVerifier.verify(token))
                 .doOnError(e -> LOG.info("failed to verify token", e));
     }
@@ -109,14 +108,14 @@ public class OpenIdValidator {
     private static Map<String, Jwk> getJwksOrderedById(JwkResponse response) {
         return response.getKeys().stream()
                 .map(jwk -> new Jwk(
-                        jwk.getKid(),
-                        jwk.getKty(),
-                        jwk.getAlg(),
-                        jwk.getUse(),
-                        jwk.getKey_ops(),
-                        jwk.getX5u(),
-                        jwk.getX5c(),
-                        jwk.getX5t(),
+                        jwk.getId(),
+                        jwk.getType(),
+                        jwk.getAlgorithm(),
+                        jwk.getUsage(),
+                        jwk.getOperations(),
+                        jwk.getCertificateUrl(),
+                        jwk.getCertificateChain(),
+                        jwk.getCertificateThumbprint(),
                         jwk.getAdditionalAttributes()))
                 .collect(Collectors.toMap(Jwk::getId, Function.identity()));
     }

--- a/impl/src/main/java/auth/openid/OpenIdValidator.java
+++ b/impl/src/main/java/auth/openid/OpenIdValidator.java
@@ -1,45 +1,134 @@
 package auth.openid;
 
+import auth.ClockProvider;
+import auth.JwkResource;
+import auth.JwkResponse;
+import com.auth0.jwk.InvalidPublicKeyException;
+import com.auth0.jwk.Jwk;
 import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
+import com.google.inject.Inject;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import rx.Observable;
 import se.fortnox.reactivewizard.jaxrs.WebException;
 
 import javax.validation.constraints.NotNull;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static auth.openid.OpenIdClaims.*;
+import static rx.Observable.just;
+import static se.fortnox.reactivewizard.util.rx.RxUtils.exception;
 
 /**
- * Validates openIds.
+ * Validates openIds. A jwk endpoint must be provided in the @{@link OpenIdConfiguration}
+ * so that the validation can be performed.
+ *
+ * Only SHA256withRSA ( specified as RS256 in jwt) is supported.
+ *
+ * Id ( specified as kid in jwt) is a mandatory field for the jwk tokens.
+ *
  */
 public class OpenIdValidator {
 
     private static final Logger LOG = LoggerFactory.getLogger(OpenIdValidator.class);
 
+    private final JwkResource jwkResource;
+    private final OpenIdConfiguration openIdConfiguration;
+    private final ClockProvider clockProvider;
+
+
+    @Inject
+    public OpenIdValidator(OpenIdConfiguration openIdConfiguration, JwkResource jwkResource, ClockProvider clockProvider) {
+        this.jwkResource = jwkResource;
+        this.openIdConfiguration = openIdConfiguration;
+        this.clockProvider = clockProvider;
+    }
 
     /**
      * Will validate that the given openId jwt is valid and contains all needed fields.
      *
+     * A @{@link WebException} with httpResponseStatus UNAUTHORIZED will be returned if the validation fails. The cause will be
+     * included in the web exception. This is so that the user never will now the cause of the failure of the validation,
+     * if it would, it could be a security issue.
+     *
      * @param openIdToken openId jwt token
      * @return a openId token object.
      */
-    public ImmutableOpenIdToken validate(@NotNull String openIdToken) {
-        final DecodedJWT decodedOpenId;
-        try {
-            decodedOpenId = JWT.decode(openIdToken);
-        } catch (Exception throwable) {
-            LOG.warn("failed to parse openId jwt", throwable);
-            throw new WebException(HttpResponseStatus.UNAUTHORIZED, throwable);
-        }
+    public Observable<ImmutableOpenIdToken> validate(@NotNull String openIdToken) {
+        return verify(openIdToken)
+                .map(this::asImmutableOpenIdToken)
+                .onErrorResumeNext(e -> exception(() -> new WebException(HttpResponseStatus.UNAUTHORIZED)));
+    }
 
-        if(decodedOpenId.getClaim(NAME).isNull() || decodedOpenId.getClaim(EMAIL).isNull() || decodedOpenId.getClaim(PICTURE).isNull()) {
-            LOG.warn("failed to validate openId jwt, missing properties in jwt");
-            throw new WebException(HttpResponseStatus.UNAUTHORIZED);
-        }
-
-
+    private ImmutableOpenIdToken asImmutableOpenIdToken(DecodedJWT decodedOpenId) {
         return new ImmutableOpenIdToken(decodedOpenId.getClaim(NAME).asString(), decodedOpenId.getClaim(EMAIL).asString(), decodedOpenId.getClaim(PICTURE).asString());
+    }
+
+    /**
+     * Verifies and decodes to OpenId token. Will validate the token with google as well as check the integrity
+     * of the jwt
+     *
+     * @param token the unverified jwt openID token
+     * @return a jwtVerifier
+     */
+    private Observable<DecodedJWT> verify(String token) {
+        final String issuer = openIdConfiguration.getIssuer();
+        final DecodedJWT unverifiedJwt = JWT.decode(token);
+        final String keyId = unverifiedJwt.getKeyId();
+        return jwkResource.getJWks()
+                .doOnError((e) -> LOG.error("failed to get jwks to verify token", e))
+                .map(OpenIdValidator::getJwksOrderedById)
+                .doOnError((e) -> LOG.error("failed to order jwks", e))
+                .flatMap(jwksById -> getPublicKeyByKeyId(keyId, jwksById))
+                .doOnError((e) -> LOG.info("failed to get jwk by kid", e))
+                .map(publicKey -> getJwtVerifier(issuer, publicKey))
+                .doOnError((e) -> LOG.info("failed to create jwt verifier", e))
+                .map(jwtVerifier -> jwtVerifier.verify(token))
+                .doOnError(e -> LOG.info("failed to verify token", e));
+    }
+
+    private JWTVerifier getJwtVerifier(String issuer, RSAPublicKey publicKey) {
+        final Algorithm rsa = Algorithm.RSA256(publicKey, null);
+        JWTVerifier.BaseVerification verification = (JWTVerifier.BaseVerification) JWT.require(rsa)
+                .withIssuer(issuer)
+                .withAudience(openIdConfiguration.getClientId())
+                .acceptLeeway(Long.MAX_VALUE); // Don't check for expiration.
+        return verification.build(clockProvider.getClock());
+    }
+
+    /**
+     * constructs a map where the key is the id ( kid ) of the jwt.
+     */
+    private static Map<String, Jwk> getJwksOrderedById(JwkResponse response) {
+        return response.getKeys().stream()
+                .map(jwk -> new Jwk(
+                        jwk.getKid(),
+                        jwk.getKty(),
+                        jwk.getAlg(),
+                        jwk.getUse(),
+                        jwk.getKey_ops(),
+                        jwk.getX5u(),
+                        jwk.getX5c(),
+                        jwk.getX5t(),
+                        jwk.getAdditionalAttributes()))
+                .collect(Collectors.toMap(Jwk::getId, Function.identity()));
+    }
+
+    private static Observable<RSAPublicKey> getPublicKeyByKeyId(String keyId, Map<String, Jwk> jwksById) {
+        try {
+            if (!jwksById.containsKey(keyId)) {
+                return Observable.error(new WebException(HttpResponseStatus.UNAUTHORIZED, "jwk key not found"));
+            }
+            return just((RSAPublicKey) jwksById.get(keyId).getPublicKey());
+        } catch (InvalidPublicKeyException e) {
+            return Observable.error(new WebException(HttpResponseStatus.UNAUTHORIZED, e));
+        }
     }
 }

--- a/impl/src/test/java/auth/JwkResourceProviderTest.java
+++ b/impl/src/test/java/auth/JwkResourceProviderTest.java
@@ -1,0 +1,38 @@
+package auth;
+
+import auth.openid.OpenIdConfiguration;
+import org.junit.Before;
+import org.junit.Test;
+import se.fortnox.reactivewizard.client.HttpClientConfig;
+
+import java.net.URI;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+
+public class JwkResourceProviderTest {
+
+    private static final String FULL_URL_PATH = "https://www.googleapis.com/oauth2/v3/certs";
+    private JwkResourceProvider jwkResourceProvider;
+
+    @Before
+    public void beforeEach() throws Exception {
+        OpenIdConfiguration openIdConfiguration = new OpenIdConfiguration();
+        openIdConfiguration.setJwksUri(FULL_URL_PATH);
+        jwkResourceProvider = new JwkResourceProvider(openIdConfiguration);
+    }
+
+    @Test
+    public void shouldReturnHttpClientThatAlwaysReturnsThePathFromTheConfig() throws Exception {
+        HttpClientConfig httpClientConfig = new HttpClientConfig(FULL_URL_PATH);
+        JwkResourceProvider.HttpClientWithHardCodedPath httpClient = (JwkResourceProvider.HttpClientWithHardCodedPath) jwkResourceProvider.getHttpClient(httpClientConfig, new URI(FULL_URL_PATH));
+
+        assertThat(httpClient.getPath(null, null, null)).isEqualTo("/oauth2/v3/certs");
+    }
+
+    @Test
+    public void shouldAlwaysReturnSameJwkResourceInstance() {
+        assertThat(jwkResourceProvider.get()).isNotNull();
+        assertThat(jwkResourceProvider.get()).isSameAs(jwkResourceProvider.get());
+    }
+}

--- a/impl/src/test/java/auth/JwkTest.java
+++ b/impl/src/test/java/auth/JwkTest.java
@@ -1,0 +1,42 @@
+package auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+
+public class JwkTest {
+
+    @Test
+    public void shouldBeAbleToDeserializeFromJson() throws IOException {
+        final ObjectMapper objectMapper = new ObjectMapper();
+
+        final String json = "{\n" +
+                "      \"kid\": \"7d680d8c70d44e947133cbd499ebc1a61c3d5abc\",\n" +
+                "      \"e\": \"AQAB\",\n" +
+                "      \"kty\": \"RSA\",\n" +
+                "      \"alg\": \"RS256\",\n" +
+                "      \"n\": \"2K7epoJWl_B68lRUi1txaa0kEuIK4WHiHpi1yC4kPyu48d046yLlrwuvbQMbog2YTOZdVoG1" +
+                "D4zlWKHuVY00O80U1ocFmBl3fKVrUMakvHru0C0mAcEUQo7ItyEX7rpOVYtxlrVk6G8PY4EK61EB-Xe35P0zb2A" +
+                "MZn7Tvm9-tLcccqYlrYBO4SWOwd5uBSqc_WcNJXgnQ-9sYEZ0JUMhKZelEMrpX72hslmduiz-LMsXCnbS7jDGcU" +
+                "uSjHXVLM9tb1SQynx5Xz9xyGeN4rQLnFIKvgwpiqnvLpbMo6grhJwrz67d1X6MwpKtAcqZ2V2v4rQsjbblNH7Gz" +
+                "F8ZsfOaqw\",\n" +
+                "      \"use\": \"sig\"\n" +
+                "    }";
+        final Jwk jwk = objectMapper.readValue(json, Jwk.class);
+
+        assertThat(jwk).isNotNull();
+        assertThat(jwk.getId()).isEqualTo("7d680d8c70d44e947133cbd499ebc1a61c3d5abc");
+        assertThat(jwk.getAlgorithm()).isEqualTo("RS256");
+        assertThat(jwk.getUsage()).isEqualTo("sig");
+
+        Map<String, Object> additionalAttributes = jwk.getAdditionalAttributes();
+        assertThat(additionalAttributes.get("e")).isEqualTo("AQAB");
+        assertThat((String) additionalAttributes.get("n")).contains("bMo6grhJwrz67d1X6MwpKtAcqZ2V2v");
+    }
+
+}

--- a/impl/src/test/java/auth/openid/OpenIdValidatorTest.java
+++ b/impl/src/test/java/auth/openid/OpenIdValidatorTest.java
@@ -1,49 +1,195 @@
 package auth.openid;
 
+import auth.ClockProvider;
+import auth.Jwk;
+import auth.JwkResource;
+import auth.JwkResponse;
+import com.auth0.jwt.interfaces.Clock;
+import com.google.common.collect.ImmutableList;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.log4j.Appender;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import se.fortnox.reactivewizard.jaxrs.WebException;
+import se.fortnox.reactivewizard.test.LoggingMockUtil;
 
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.Date;
+
+import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.*;
+import static rx.Observable.just;
+import static se.fortnox.reactivewizard.test.TestUtil.matches;
 
 public class OpenIdValidatorTest {
 
-    private static final String SIMPLE_JWT  ="eyJhbGciOiJIUzI1NiIsImtpZCI6ImIxNWEyYjhmN2E2YjNmNmJjMDhiYzFjNTZhODg0MTBlMTQ2ZDAxZmQiLCJ0eXAiOiJKV1QifQ.eyJlbWFpbCI6ImplcHAzX2RyYWdvbnNsYXllckBmb3J0bm94LnNlIiwibmFtZSI6ImplcHAzIiwicGljdHVyZSI6InVybHRvcGljdHVyZSIsInVzZXJfaWQiOjEsImlhdCI6MTU0ODQxNzY0NywiZXhwIjoxNTQ4NDIxMjQ3fQ.yDPCbMe5ZPqNubrWBoJJytk3DqS5FiEVotirtj3wzNA";
-    private static final String INVALID_JWT  ="eyJhbGciOiJIUzI1NiIsImtpZCI6ImIxNWEyYjhmN2E2YjNmNmJjMDhiYzFjNTZhODg0MTBlMTQ2ZDAxZmQiLCJ0eXAiOiJKV1QifQ.eyJuYW1lIjoiamVwcDMiLCJwaWN0dXJlIjoidXJsdG9waWN0dXJlIiwidXNlcl9pZCI6MSwiaWF0IjoxNTQ4NDE3NjQ3LCJleHAiOjE1NDg0MjEyNDd9.T0GzQRUZyncGZj9MYShgvFVV0GJXH1jDv0V2WU7n9OU";
+    private static final String OPEN_ID = "eyJhbGciOiJSUzI1NiIsImtpZCI6IjdkNjgwZDhjNzBkNDRlOTQ3MTMzY2JkNDk5ZWJj" +
+            "MWE2MWMzZDVhYmMiLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJhenAiOiI5MjE" +
+            "zMTAzODczOTQtY2k0Mzd0ZnJjYzRyMW8zMGhxczNtcm5tcnBwNDBvajAuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJhd" +
+            "WQiOiI5MjEzMTAzODczOTQtY2k0Mzd0ZnJjYzRyMW8zMGhxczNtcm5tcnBwNDBvajAuYXBwcy5nb29nbGV1c2VyY29udGVudC5" +
+            "jb20iLCJzdWIiOiIxMDU0MzE0NDE1NTA3MjI0OTY2NDMiLCJlbWFpbCI6Implc3Blci5sYWhkZXZpcnRhQGdtYWlsLmNvbSIsI" +
+            "mVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJhdF9oYXNoIjoidVdfZkYzcDN1SkxMMmJhYjFNUVllZyIsIm5hbWUiOiJKZXNwZXIgRXJ" +
+            "sYW5kc3NvbiIsInBpY3R1cmUiOiJodHRwczovL2xoNS5nb29nbGV1c2VyY29udGVudC5jb20vLTNXb2U4RWdzcWtzL0FBQUFBQ" +
+            "UFBQUFJL0FBQUFBQUFBQUtBLzVlY1oxVS1tZEpBL3M5Ni1jL3Bob3RvLmpwZyIsImdpdmVuX25hbWUiOiJKZXNwZXIiLCJmYW1" +
+            "pbHlfbmFtZSI6IkVybGFuZHNzb24iLCJsb2NhbGUiOiJzdiIsImlhdCI6MTU1MDYxMDAwOSwiZXhwIjoxNTUwNjEzNjA5fQ.rf" +
+            "5GuX5kFdz3DNgXW7zvH_XF5YOwzEk-H7PHrvaSXYD6knU6ARmAmGnRCK0sWmOvGEKt9R-99NY0O7gS1ynsKpQr2EIwdilCR8rW" +
+            "2V3fcfvWZGQPc6vTp8ntNl3oWqe4sPBYm3pBzsWEr9Jm81LHsWieUzohvwA1KtVX1sxt21iFtKcS9-zSoX9JebRqs-DpnqlPaF" +
+            "v42mN9wsap7oY1D1Xy_4-KWxujBuaLHhXjxv4My_MLR5crw1qeLotE1S4hI8edgYwntUz9Txd3wBfT-oVKFBbagMA81F5XMd9E" +
+            "vDhiKjgg-Naz05ptZoOcvQJ4rWAqaXfmuejq4u1AKqHiMQ";
 
-    private OpenIdValidator openIdValidator = new OpenIdValidator();
+    private JwkResource jwkResource = mock(JwkResource.class);
+    private Appender appender;
+    private OpenIdConfiguration openIdConfiguration;
+    private ClockProvider clockProvider;
 
+    @Before
+    public void beforeEach() throws NoSuchFieldException, IllegalAccessException {
+        appender = LoggingMockUtil.createMockedLogAppender(OpenIdValidator.class);
+        openIdConfiguration = getValidOpenIdConfiguration();
+        Date currentTime = getValidTimeInterval();
+        clockProvider = () -> (Clock) () -> currentTime;
+
+        JwkResponse jwkResponse = new JwkResponse();
+        jwkResponse.setKeys(ImmutableList.of(getValidJwk()));
+        when(jwkResource.getJWks()).thenReturn(just(jwkResponse));
+    }
+
+    @After
+    public void afterEach() throws NoSuchFieldException, IllegalAccessException {
+        LoggingMockUtil.destroyMockedAppender(appender, OpenIdValidator.class);
+    }
 
     @Test
     public void shouldValidateSimpleJWT() {
+        // given a valid config and a valid key
+        OpenIdValidator openIdValidator = new OpenIdValidator(openIdConfiguration, jwkResource, clockProvider);
 
-        ImmutableOpenIdToken token = openIdValidator.validate(SIMPLE_JWT);
+        // when
+        ImmutableOpenIdToken token = openIdValidator.validate(OPEN_ID).toBlocking().single();
 
-       assertEquals("jepp3",token.name);
-       assertEquals("jepp3_dragonslayer@fortnox.se",token.email);
-       assertEquals("urltopicture",token.picture);
-
+        // then the token should exist and contain proper values
+        assertThat(token).isNotNull();
+        assertThat(token.name).startsWith("Jesper");
+        assertThat(token.email).startsWith("jesper");
+        assertThat(token.picture).isNotNull();
     }
 
     @Test
-    public void shouldThrowWebExceptionIfJWTMissesImportantInformation() {
+    public void shouldNotValidateExpiredJWT() {
 
+        // given a time when the jwt has expired
+        long milliseconds = LocalDateTime.parse("2019-02-19T23:14:17.290").toInstant(ZoneOffset.UTC).toEpochMilli();
+        Date currentTime = new Date(milliseconds);
+        ClockProvider clockProvider = () -> (Clock) () -> currentTime;
+
+        // when
+        OpenIdValidator openIdValidator = new OpenIdValidator(openIdConfiguration, jwkResource, clockProvider);
+        validateWithExpectedUnauthorized(openIdValidator);
+
+        // then we should log that we could not verify the token
+        verify(appender).doAppend(matches(log -> {
+            assertThat(log.getLevel().toString()).isEqualTo("INFO");
+            assertThat(log.getMessage().toString()).contains("failed to verify token");
+        }));
+
+
+    }
+
+    private void validateWithExpectedUnauthorized(OpenIdValidator openIdValidator) {
         try {
-           openIdValidator.validate(INVALID_JWT);
-            fail("should have thrown " + WebException.class.getName());
-        } catch (WebException webException) {
-            assertEquals(HttpResponseStatus.UNAUTHORIZED, webException.getStatus());
+            openIdValidator.validate(OPEN_ID).toBlocking().single();
+            fail("expected exception");
+        } catch (WebException e) {
+            assertEquals("unauthorized", e.getError());
+            assertEquals(HttpResponseStatus.UNAUTHORIZED, e.getStatus());
         }
     }
 
     @Test
-    public void shouldThrowWebExceptionIfJWTCannotBeParsed() {
-        try {
-            openIdValidator.validate("brutalInvalidJson");
-            fail("should have thrown " + WebException.class.getName());
-        } catch (WebException webException) {
-            assertEquals(HttpResponseStatus.UNAUTHORIZED, webException.getStatus());
-        }
+    public void shouldNotValidateJwkWhenKeyCannotBeVerified() {
+        // given no keys
+        JwkResponse jwkResponse = new JwkResponse();
+        jwkResponse.setKeys(Collections.emptyList());
+        when(jwkResource.getJWks()).thenReturn(just(jwkResponse));
+
+        // when
+        OpenIdValidator openIdValidator = new OpenIdValidator(openIdConfiguration, jwkResource, clockProvider);
+        validateWithExpectedUnauthorized(openIdValidator);
+
+        // then we should log that we failed to get jwk by kid
+        verify(appender).doAppend(matches(log -> {
+            assertThat(log.getLevel().toString()).isEqualTo("INFO");
+            assertThat(log.getMessage().toString()).contains("failed to get jwk by kid");
+        }));
     }
+
+    @Test
+    public void shouldNotValidateJwkWhenIssuerIsIncorrect() {
+        // given wrong issuer
+        openIdConfiguration.setIssuer("wrong issuer");
+
+        // when
+        OpenIdValidator openIdValidator = new OpenIdValidator(openIdConfiguration, jwkResource, clockProvider);
+        validateWithExpectedUnauthorized(openIdValidator);
+
+        // then we should log that we could not verify the token
+        verify(appender).doAppend(matches(log -> {
+            assertThat(log.getLevel().toString()).isEqualTo("INFO");
+            assertThat(log.getMessage().toString()).contains("failed to verify token");
+        }));
+
+    }
+
+    @Test
+    public void shouldNotValidateJwkWhenVerifierCannotBeCreated() {
+        // given bad openid configuration
+        ClockProvider clockProvider = () -> {
+            throw new NullPointerException("poff");
+        };
+
+        // when
+        OpenIdValidator openIdValidator = new OpenIdValidator(openIdConfiguration, jwkResource, clockProvider);
+        validateWithExpectedUnauthorized(openIdValidator);
+
+        // then we should log that we could not verify the token
+        verify(appender).doAppend(matches(log -> {
+            assertThat(log.getLevel().toString()).isEqualTo("INFO");
+            assertThat(log.getMessage().toString()).contains("failed to verify token");
+        }));
+    }
+
+    private OpenIdConfiguration getValidOpenIdConfiguration() {
+        OpenIdConfiguration openIdConfiguration = new OpenIdConfiguration();
+        openIdConfiguration.setClientId("921310387394-ci437tfrcc4r1o30hqs3mrnmrpp40oj0.apps.googleusercontent.com");
+        openIdConfiguration.setJwksUri("https://www.googleapis.com/oauth2/v3/certs");
+        openIdConfiguration.setIssuer("https://accounts.google.com");
+        return openIdConfiguration;
+    }
+
+    private Jwk getValidJwk() {
+        Jwk jwk = new Jwk();
+
+        jwk.setKid("7d680d8c70d44e947133cbd499ebc1a61c3d5abc");
+        jwk.setE("AQAB");
+        jwk.setKty("RSA");
+        jwk.setAlg("RS256");
+        jwk.setN("2K7epoJWl_B68lRUi1txaa0kEuIK4WHiHpi1yC4kPyu48d046yLlrwuvbQMbog2YTOZdV" +
+                "oG1D4zlWKHuVY00O80U1ocFmBl3fKVrUMakvHru0C0mAcEUQo7ItyEX7rpOVYtxlrVk6G8PY4" +
+                "EK61EB-Xe35P0zb2AMZn7Tvm9-tLcccqYlrYBO4SWOwd5uBSqc_WcNJXgnQ-9sYEZ0JUMhKZel" +
+                "EMrpX72hslmduiz-LMsXCnbS7jDGcUuSjHXVLM9tb1SQynx5Xz9xyGeN4rQLnFIKvgwpiqnvLpbMo6" +
+                "grhJwrz67d1X6MwpKtAcqZ2V2v4rQsjbblNH7GzF8ZsfOaqw");
+        jwk.setUse("sig");
+        return jwk;
+    }
+
+    private Date getValidTimeInterval() {
+        long milliseconds = LocalDateTime.parse("2019-02-19T21:14:17.290").toInstant(ZoneOffset.UTC).toEpochMilli();
+        return new Date(milliseconds);
+    }
+
 }

--- a/impl/src/test/java/auth/openid/OpenIdValidatorTest.java
+++ b/impl/src/test/java/auth/openid/OpenIdValidatorTest.java
@@ -174,16 +174,16 @@ public class OpenIdValidatorTest {
     private Jwk getValidJwk() {
         Jwk jwk = new Jwk();
 
-        jwk.setKid("7d680d8c70d44e947133cbd499ebc1a61c3d5abc");
-        jwk.setE("AQAB");
-        jwk.setKty("RSA");
-        jwk.setAlg("RS256");
-        jwk.setN("2K7epoJWl_B68lRUi1txaa0kEuIK4WHiHpi1yC4kPyu48d046yLlrwuvbQMbog2YTOZdV" +
+        jwk.setId("7d680d8c70d44e947133cbd499ebc1a61c3d5abc");
+        jwk.setType("RSA");
+        jwk.setAlgorithm("RS256");
+        jwk.setUsage("sig");
+        jwk.setAdditionalAttributes("n", "2K7epoJWl_B68lRUi1txaa0kEuIK4WHiHpi1yC4kPyu48d046yLlrwuvbQMbog2YTOZdV" +
                 "oG1D4zlWKHuVY00O80U1ocFmBl3fKVrUMakvHru0C0mAcEUQo7ItyEX7rpOVYtxlrVk6G8PY4" +
                 "EK61EB-Xe35P0zb2AMZn7Tvm9-tLcccqYlrYBO4SWOwd5uBSqc_WcNJXgnQ-9sYEZ0JUMhKZel" +
                 "EMrpX72hslmduiz-LMsXCnbS7jDGcUuSjHXVLM9tb1SQynx5Xz9xyGeN4rQLnFIKvgwpiqnvLpbMo6" +
                 "grhJwrz67d1X6MwpKtAcqZ2V2v4rQsjbblNH7GzF8ZsfOaqw");
-        jwk.setUse("sig");
+        jwk.setAdditionalAttributes("e", "AQAB");
         return jwk;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,24 @@
     </repositories>
     <dependencies>
         <dependency>
+            <groupId>org.easytesting</groupId>
+            <artifactId>fest-assert</artifactId>
+            <version>1.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>se.fortnox.reactivewizard</groupId>
+            <artifactId>reactivewizard-test</artifactId>
+            <version>${reactivewizard.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>42.2.5</version>
@@ -68,6 +86,11 @@
             <version>${reactivewizard.version}</version>
         </dependency>
         <dependency>
+            <groupId>se.fortnox.reactivewizard</groupId>
+            <artifactId>reactivewizard-client</artifactId>
+            <version>${reactivewizard.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>1.9.5</version>
@@ -85,7 +108,6 @@
             <version>2.9.8</version>
         </dependency>
     </dependencies>
-
        <build>
             <plugins>
                 <plugin>
@@ -99,6 +121,4 @@
                 </plugin>
             </plugins>
         </build>
-
-
 </project>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -36,19 +36,6 @@
             <version>1.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
-            <version>1.4</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <version>1.3</version>
-        </dependency>
-
     </dependencies>
 
 </project>

--- a/spec/src/test/java/TestSetup.java
+++ b/spec/src/test/java/TestSetup.java
@@ -1,6 +1,7 @@
 import api.Question;
 import api.User;
 import api.UserResource;
+import auth.JwkResource;
 import auth.application.ApplicationTokenConfig;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -9,7 +10,6 @@ import com.google.inject.Module;
 import com.google.inject.name.Names;
 import com.google.inject.util.Modules;
 import org.jetbrains.annotations.NotNull;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -24,9 +24,7 @@ import slack.SlackRTMClient;
 
 import java.util.UUID;
 
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class TestSetup {
 
@@ -47,8 +45,9 @@ public class TestSetup {
             .with(mocks, new AbstractModule() {
                 @Override
                 protected void configure() {
-                    SlackRTMClient slackRTMClient = Mockito.mock(SlackRTMClient.class);
+                    SlackRTMClient slackRTMClient = mock(SlackRTMClient.class);
                     binder().bind(SlackRTMClient.class).toInstance(slackRTMClient);
+                    binder().bind(JwkResource.class).toProvider(() -> mock(JwkResource.class));
                 }
             })));
     }

--- a/spec/src/test/java/TestSetup.java
+++ b/spec/src/test/java/TestSetup.java
@@ -24,8 +24,7 @@ import slack.SlackRTMClient;
 
 import java.util.UUID;
 
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class TestSetup {
 

--- a/spec/src/test/java/UserResourceTest.java
+++ b/spec/src/test/java/UserResourceTest.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
+import static rx.Observable.just;
 
 public class UserResourceTest {
     private static final String OPEN_ID_TOKEN = "eyJhbGciOiJIUzI1NiIsImtpZCI6ImIxNWEyYjhmN2E2YjNmNmJjMDhiYzFjNTZhODg0MTBlMTQ2ZDAxZmQiLCJ0eXAiOiJKV1QifQ.eyJuYW1lIjoiamVwcDMiLCJwaWN0dXJlIjoidXJsdG9waWN0dXJlIiwiZW1haWwiOiJqZXNwZXIubGFoZGV2aXJ0YUBnbWFpbC5jb20iLCJpYXQiOjE1NDg0MTc2NDcsImV4cCI6MTY0ODQyMTI0N30.WH70YBPaMFg1QtTaZddikcslsN2C5sxm4oQSOVIt_PU";
@@ -63,7 +64,7 @@ public class UserResourceTest {
     public void shouldCreateUserInDatabaseIfFirstTimeLogin() {
         // given
         ImmutableOpenIdToken openIdObject = new ImmutableOpenIdToken("jeppe", "jeppe@email.com", "pictureUrl");
-        when(openIdValidator.validate(any())).thenReturn(openIdObject);
+        when(openIdValidator.validate(any())).thenReturn(just(openIdObject));
 
         // when
         ApplicationToken applicationToken = userResource.generateToken(OPEN_ID_TOKEN).toBlocking().singleOrDefault(null);
@@ -79,7 +80,7 @@ public class UserResourceTest {
         // given
         User user = insertUser();
         ImmutableOpenIdToken openIdObject = new ImmutableOpenIdToken(user.getName(), user.getEmail(), "pictureUrl");
-        when(openIdValidator.validate(any())).thenReturn(openIdObject);
+        when(openIdValidator.validate(any())).thenReturn(just(openIdObject));
 
         // when
         ApplicationToken applicationToken = userResource.generateToken(OPEN_ID_TOKEN).toBlocking().singleOrDefault(null);
@@ -95,7 +96,7 @@ public class UserResourceTest {
         // given
         User user = insertUser();
         ImmutableOpenIdToken openIdObject = new ImmutableOpenIdToken(user.getName(), user.getEmail(), "pictureUrl");
-        when(openIdValidator.validate(any())).thenReturn(openIdObject);
+        when(openIdValidator.validate(any())).thenReturn(just(openIdObject));
 
         // when
         ApplicationToken applicationToken = userResource.generateToken(OPEN_ID_TOKEN).toBlocking().singleOrDefault(null);


### PR DESCRIPTION
We will now verify the token with a jwk endpoint that exposes public keys. This is needed for openId verification, as well as it works for verification of jwks with RSA256, when we dont want to bind the application to a specific jwt secret, that can be hard to change. 

The flow of auth of the application: 

1. user goes to rocket fuel
2. frontend creates an openId when user signs in with google js openid lib
3. frontend sends the openId to to backend, in exchange for an application token ,that is set in a cookie by the backend.  (The backend validates the token with help of google and persists the user in the db, if the user is unknown to rocket fuel)

The frontend can now call the protected api:s due to the application token placed in a cookie. The auth resolver will only accept valid application tokens, or a unauthorized response will be returned.
