### PR TITLE
refactor how code coverage is configured with maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,12 +13,12 @@
         <module>impl</module>
         <module>spec</module>
         <module>ui</module>
+        <module>report</module>
     </modules>
     <properties>
         <slf4j.version>1.7.22</slf4j.version>
         <reactivewizard.version>1.1.0</reactivewizard.version>
         <antrun.plugin.version>1.7</antrun.plugin.version>
-        <jacoco.plugin.version>0.8.2</jacoco.plugin.version>
         <argLine>-Xmx6G</argLine>
     </properties>
 
@@ -102,24 +102,46 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>${jacoco.plugin.version}</version>
                     <executions>
                         <execution>
+                            <id>prepare-agent</id>
                             <goals>
                                 <goal>prepare-agent</goal>
-                            </goals>
-                        </execution>
-                        <execution>
-                            <id>report</id>
-                            <phase>prepare-package</phase>
-                            <goals>
-                                <goal>report</goal>
                             </goals>
                         </execution>
                     </executions>
                 </plugin>
             </plugins>
-        </build>
 
+           <pluginManagement>
+               <plugins>
+                   <plugin>
+                       <groupId>org.jacoco</groupId>
+                       <artifactId>jacoco-maven-plugin</artifactId>
+                       <version>0.8.3</version>
+                   </plugin>
+                   <plugin>
+                       <groupId>org.apache.maven.plugins</groupId>
+                       <artifactId>maven-compiler-plugin</artifactId>
+                       <version>2.3.2</version>
+                       <configuration>
+                           <source>1.8</source>
+                           <target>1.8</target>
+                       </configuration>
+                   </plugin>
+                   <plugin>
+                       <groupId>org.apache.maven.plugins</groupId>
+                       <artifactId>maven-surefire-plugin</artifactId>
+                       <version>2.9</version>
+                   </plugin>
+                   <plugin>
+                       <groupId>org.apache.maven.plugins</groupId>
+                       <artifactId>maven-jar-plugin</artifactId>
+                       <version>2.3.1</version>
+                   </plugin>
+               </plugins>
+           </pluginManagement>
+
+       </build>
 
 </project>

--- a/report/pom.xml
+++ b/report/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>rocket-fuel</artifactId>
+        <groupId>se.fortnox</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <name>Aggregated jacoco report</name>
+    <artifactId>report</artifactId>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>se.fortnox</groupId>
+            <artifactId>impl</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>se.fortnox</groupId>
+            <artifactId>api</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>se.fortnox</groupId>
+            <artifactId>spec</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>report-aggregate</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report-aggregate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,4 +11,4 @@ sonar.sources=.
 
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8
-sonar.coverage.jacoco.xmlReportPaths=spec/target/coverage-report/coverage-report.xml
+sonar.coverage.jacoco.xmlReportPaths=report/target/site/jacoco-aggregate/jacoco.xml

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -8,18 +8,7 @@
         <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <properties>
-        <build.directory.impl>../impl/target</build.directory.impl>
-        <build.directory.spec>target</build.directory.spec>
 
-        <classes.directory.impl>../impl/target/classes</classes.directory.impl>
-
-        <sources.directory.impl>../impl/src/main/java</sources.directory.impl>
-
-        <generated-sources.directory.impl>../impl/target/generated-sources/annotations
-        </generated-sources.directory.impl>
-        <generated-sources.directory.spec>target/generated-sources/annotations</generated-sources.directory.spec>
-    </properties>
     <artifactId>spec</artifactId>
 
     <dependencies>
@@ -62,62 +51,4 @@
 
     </dependencies>
 
-    <build>
-        <plugins>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.6</version>
-                <executions>
-                    <execution>
-                        <phase>post-integration-test</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target>
-                                <!-- Execute an ant task within maven -->
-                                <echo message="Generating JaCoCo Reports"/>
-                                <taskdef name="report" classname="org.jacoco.ant.ReportTask">
-                                    <classpath path="${basedir}/target/jacoco-jars/org.jacoco.ant.jar"/>
-                                </taskdef>
-                                <mkdir dir="${basedir}/target/coverage-report"/>
-                                <report>
-                                    <executiondata>
-                                        <fileset dir="${build.directory.impl}">
-                                            <include name="jacoco.exec"/>
-                                        </fileset>
-                                        <fileset dir="${build.directory.spec}">
-                                            <include name="jacoco.exec"/>
-                                        </fileset>
-                                    </executiondata>
-                                    <structure name="jacoco-multi Coverage Project">
-                                        <group name="jacoco-multi">
-                                            <classfiles>
-                                                <fileset dir="${classes.directory.impl}"/>
-                                            </classfiles>
-                                            <sourcefiles encoding="UTF-8">
-                                                <fileset dir="${sources.directory.impl}"/>
-                                            </sourcefiles>
-                                        </group>
-                                    </structure>
-                                    <html destdir="${basedir}/target/coverage-report/html"/>
-                                    <xml destfile="${basedir}/target/coverage-report/coverage-report.xml"/>
-                                    <csv destfile="${basedir}/target/coverage-report/coverage-report.csv"/>
-                                </report>
-                            </target>
-                        </configuration>
-                    </execution>
-                </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.jacoco</groupId>
-                        <artifactId>org.jacoco.ant</artifactId>
-                        <version>${jacoco.plugin.version}</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-        </plugins>
-    </build>
 </project>


### PR DESCRIPTION
I found out a cleaner way to collect the coverage, as described in jacocos own repository. https://github.com/jacoco/jacoco/tree/master/jacoco-maven-plugin.test

The idea here is to have a mvn module to run the coverage. For me thats fine, some would want to have it included in the spec folder. But i think it pollutes the spec pom file with things that are general for the entire project. 