### PR TITLE
user assertj instead of fest assertions.

### DIFF
--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -38,9 +38,10 @@
         </dependency>
 
         <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
-            <version>1.4</version>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.11.1</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/spec/src/test/java/QuestionResourceTest.java
+++ b/spec/src/test/java/QuestionResourceTest.java
@@ -11,7 +11,7 @@ import se.fortnox.reactivewizard.jaxrs.WebException;
 
 import java.util.List;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 

--- a/spec/src/test/java/ThreadMessageHandlerTest.java
+++ b/spec/src/test/java/ThreadMessageHandlerTest.java
@@ -1,17 +1,8 @@
-import api.Answer;
-import api.AnswerResource;
-import api.Question;
-import api.QuestionResource;
-import api.User;
-import api.UserResource;
+import api.*;
 import com.github.seratch.jslack.api.model.Message;
 import com.google.gson.JsonObject;
 import com.google.inject.AbstractModule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.*;
 import org.mockito.Mockito;
 import org.testcontainers.containers.PostgreSQLContainer;
 import slack.SlackResource;
@@ -19,14 +10,11 @@ import slack.ThreadMessageHandler;
 
 import java.util.List;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static rx.Observable.empty;
 import static rx.Observable.just;
 


### PR DESCRIPTION
AssertJ is a fork of  Fest Assert library which is not maintained anymore. Therefor we should migrate over to Assertj. 

Documention over assertj can be found here: 
http://joel-costigliola.github.io/assertj/index.html