### PR TITLE
Automate release to scm

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ run maven clean package in the root folder. It will execute all the tests and ge
 
 The tests inside the spec module requires docker and at least two gigabytes of free space. The reason is that a postgres container is used to test the sql queries.
 
-#### Release 
+#### Release
 
 When a feature or bug has been merged, a release can be made. The release consists of two steps. The first one is the typical scm release performed with maven release pluging. The second step pushes the docker images to dockerhub. Both steps must be made, otherwise the release will not be considered successful.
 
@@ -54,11 +54,12 @@ Then in the root of the project type the following:
 
 ```mvn release:prepare``` 
 
-Now its time to do a real release scm release.
+Now its time to do a real scm release.
 
 ```mvn release:perform```
 
 The first step in the release proccess has been made. You can now run:
+
 ```mvn deploy```
 
 This will push the images to dockerhub. A complete release has now been performed.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ First make sure you are on a updated master branch without any local commits. Th
 
 Then in the root of the project type the following:
 
-`````mvn release:prepare````` 
+````mvn release:prepare```` 
 
 Now its time to do a real release scm release.
 
@@ -60,6 +60,6 @@ Now its time to do a real release scm release.
 
 The first step in the release proccess has been made. You can now run:
 
-`````mvn deploy`````
+````mvn deploy````
 
 This will push the images to dockerhub. A complete release has now been performed.

--- a/README.md
+++ b/README.md
@@ -52,14 +52,13 @@ First make sure you are on a updated master branch without any local commits. Th
 
 Then in the root of the project type the following:
 
-````mvn release:prepare```` 
+```mvn release:prepare``` 
 
 Now its time to do a real release scm release.
 
 ```mvn release:perform```
 
 The first step in the release proccess has been made. You can now run:
-
-````mvn deploy````
+```mvn deploy```
 
 This will push the images to dockerhub. A complete release has now been performed.

--- a/README.md
+++ b/README.md
@@ -43,3 +43,23 @@ Import the project as a maven project. Intellij will probably fix this for you. 
 run maven clean package in the root folder. It will execute all the tests and generate a fat jar for you, that you can execute with java -jar.
 
 The tests inside the spec module requires docker and at least two gigabytes of free space. The reason is that a postgres container is used to test the sql queries.
+
+#### Release 
+
+When a feature or bug has been merged, a release can be made. The release consists of two steps. The first one is the typical scm release performed with maven release pluging. The second step pushes the docker images to dockerhub. Both steps must be made, otherwise the release will not be considered successful.
+
+First make sure you are on a updated master branch without any local commits. The branch should be identical to the remote master. Make sure you have ssh keys in place. Only ssh is supported currently. You need to make sure you have access to dockerhub. You will need to provide credentials in your settings.xml file for this. 
+
+Then in the root of the project type the following:
+
+`````mvn release:prepare````` 
+
+Now its time to do a real release scm release.
+
+```mvn release:perform```
+
+The first step in the release proccess has been made. You can now run:
+
+`````mvn deploy`````
+
+This will push the images to dockerhub. A complete release has now been performed.

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>se.fortnox</groupId>
         <artifactId>rocket-fuel</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.1.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>se.fortnox</groupId>
         <artifactId>rocket-fuel</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.1.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>se.fortnox</groupId>
             <artifactId>rocket-fuel-api</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.3-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,18 +15,34 @@
         <module>ui</module>
         <module>report</module>
     </modules>
+
     <properties>
         <slf4j.version>1.7.22</slf4j.version>
         <reactivewizard.version>1.6.0</reactivewizard.version>
         <antrun.plugin.version>1.7</antrun.plugin.version>
         <sonar.coverage.jacoco.xmlReportPaths>report/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+        <project.scm.id>my-scm-server</project.scm.id>
     </properties>
+
+    <url>https://github.com/FortnoxAB/rocket-fuel</url>
+
+    <organization>
+        <name>Fortnox AB</name>
+        <url>http://www.fortnox.se</url>
+    </organization>
 
     <scm>
         <connection>scm:git:git@github.com:FortnoxAB/rocket-fuel.git</connection>
         <developerConnection>scm:git:git@github.com:FortnoxAB/rocket-fuel.git</developerConnection>
         <url>https://github.com/FortnoxAB/rocket-fuel/tree/master</url>
     </scm>
+
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+        </license>
+    </licenses>
 
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,12 @@
         <sonar.coverage.jacoco.xmlReportPaths>report/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
+    <scm>
+        <connection>scm:git:git@github.com:FortnoxAB/rocket-fuel.git</connection>
+        <developerConnection>scm:git:git@github.com:FortnoxAB/rocket-fuel.git</developerConnection>
+        <url>https://github.com/FortnoxAB/rocket-fuel/tree/master</url>
+    </scm>
+
     <repositories>
         <repository>
             <id>oss-sonatype</id>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <reactivewizard.version>1.6.0</reactivewizard.version>
         <antrun.plugin.version>1.7</antrun.plugin.version>
         <sonar.coverage.jacoco.xmlReportPaths>report/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
-        <project.scm.id>my-scm-server</project.scm.id>
+        <autoVersionSubmodules>true</autoVersionSubmodules>
     </properties>
 
     <url>https://github.com/FortnoxAB/rocket-fuel</url>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>se.fortnox</groupId>
     <artifactId>rocket-fuel</artifactId>
     <packaging>pom</packaging>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.1.3-SNAPSHOT</version>
     <modules>
         <module>api</module>
         <module>impl</module>

--- a/report/pom.xml
+++ b/report/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>se.fortnox</groupId>
         <artifactId>rocket-fuel</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.1.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Aggregated jacoco report</name>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>se.fortnox</groupId>
         <artifactId>rocket-fuel</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.1.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>se.fortnox</groupId>
             <artifactId>rocket-fuel-impl</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.3-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
         <groupId>se.fortnox</groupId>
         <artifactId>rocket-fuel</artifactId>
-		<version>1.0-SNAPSHOT</version>
+		<version>0.1.3-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Configured the mvn release plugin to reduce manual work. The plugin will perform a scm release. No articafts will be pushed to maven central. But there is still no need for that. So we will add that support when we feel that its needed.