### PR TITLE
update picture and name when user sign in.

### DIFF
--- a/impl/src/main/java/dao/UserDao.java
+++ b/impl/src/main/java/dao/UserDao.java
@@ -17,4 +17,8 @@ public interface UserDao {
 
     @Query(value = "SELECT * from \"user\" where id = :userId LIMIT 1")
     Observable<User> getUserById(long userId);
+    @Update("UPDATE \"user\" " +
+        "SET name=:name, picture=:picture " +
+        "WHERE id=:userId")
+    Observable<Integer> updateUser(Long userId, String name, String picture);
 }

--- a/impl/src/main/java/impl/UserResourceImpl.java
+++ b/impl/src/main/java/impl/UserResourceImpl.java
@@ -113,7 +113,7 @@ public class UserResourceImpl implements UserResource {
     }
 
     private String getPicture(String picture) {
-        if(picture == null) {
+        if(picture == null || picture.isEmpty()) {
             return DEFAULT_PICTURE_URL;
         }
         return picture;

--- a/spec/src/test/java/impl/UserResourceTest.java
+++ b/spec/src/test/java/impl/UserResourceTest.java
@@ -295,7 +295,7 @@ public class UserResourceTest {
     }
 
     private User insertUser(String name, String picture) {
-        final String generatedEmail = UUID.randomUUID().toString() + "@fortnox.se";
+        final String generatedEmail = UUID.randomUUID().toString() + "@example.com";
         User user = new User();
         user.setEmail(generatedEmail);
         user.setName(name);

--- a/spec/src/test/java/impl/UserResourceTest.java
+++ b/spec/src/test/java/impl/UserResourceTest.java
@@ -10,7 +10,11 @@ import dao.UserDao;
 import dates.DateProvider;
 import dates.DateProviderImpl;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.testcontainers.containers.PostgreSQLContainer;
 import se.fortnox.reactivewizard.jaxrs.WebException;
@@ -23,9 +27,19 @@ import static impl.UserResourceImpl.FAILED_TO_UPDATE_USER_NAME_OR_PICTURE;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static rx.Observable.error;
 import static rx.Observable.just;
 
@@ -169,7 +183,7 @@ public class UserResourceTest {
         UserDao userDao = testSetup.getInjector().getInstance(UserDao.class);
         UserDao userDaoMock = mock(UserDao.class);
         //but the update sql yields errors
-        doAnswer((answer)-> userDao.insertUser((User)answer.getArguments()[0])).when(userDaoMock).insertUser(any());
+        doAnswer((answer)-> error(new Exception("should.not.be.executed"))).when(userDaoMock).insertUser(any());
         doAnswer(answer -> userDao.getUserByEmail((String)answer.getArguments()[0])).when(userDaoMock).getUserByEmail(anyString());
 
         doReturn(error(new SQLException("poff"))).when(userDaoMock).updateUser(any(),anyString(),anyString());

--- a/spec/src/test/java/impl/UserResourceTest.java
+++ b/spec/src/test/java/impl/UserResourceTest.java
@@ -188,7 +188,7 @@ public class UserResourceTest {
 
         doReturn(error(new SQLException("poff"))).when(userDaoMock).updateUser(any(),anyString(),anyString());
 
-        userResource = new UserResourceImpl(userDaoMock, responseHeaderHolder, openIdValidator, applicationTokenCreator, applicationTokenConfig);
+        UserResource userResource = new UserResourceImpl(userDaoMock, responseHeaderHolder, openIdValidator, applicationTokenCreator, applicationTokenConfig);
 
         // and that the user has changed name since last visit
         ImmutableOpenIdToken openId = new ImmutableOpenIdToken("Arnold", user.getEmail(), user.getPicture());


### PR DESCRIPTION
Now when user signs in, we will diff the stored name & picture with the one given in the openId. If they are different we will update name and picture in the database. So that rocket fuel profile is updated. 

assertion helper for errors will be created in separate pull request.

I decided to update both name and picture with the same query. It reduced some complexity. Less i more or something..