### PR TITLE
Expose createdAt as ZonedDateTime in order for the ui to be able to s…

### DIFF
--- a/api/src/main/java/api/Post.java
+++ b/api/src/main/java/api/Post.java
@@ -1,6 +1,13 @@
  package api;
 
+ import com.fasterxml.jackson.annotation.JsonIgnore;
+ import com.fasterxml.jackson.annotation.JsonProperty;
+
  import java.time.LocalDateTime;
+ import java.time.ZonedDateTime;
+
+ import static java.time.ZoneId.systemDefault;
+ import static java.util.Optional.ofNullable;
 
  /**
   * A class that defines the shared attributes between a {@link Answer}
@@ -31,6 +38,14 @@
         this.createdBy = createdBy;
     }
 
+    @JsonProperty("createdAt")
+    public ZonedDateTime getCreated() {
+        return ofNullable(createdAt)
+            .map(time -> time.atZone(systemDefault()))
+            .orElse(null);
+    }
+
+    @JsonIgnore
     public LocalDateTime getCreatedAt() {
         return createdAt;
     }

--- a/spec/src/test/java/impl/AnswerResourceTest.java
+++ b/spec/src/test/java/impl/AnswerResourceTest.java
@@ -25,6 +25,7 @@ import se.fortnox.reactivewizard.db.transactions.DaoTransactions;
 import se.fortnox.reactivewizard.jaxrs.WebException;
 import slack.SlackResource;
 
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
@@ -302,6 +303,10 @@ public class AnswerResourceTest {
         assertEquals("this is the body of the answer", createdAnswer.getAnswer());
         assertThat(createdAnswer.getVotes()).isZero();
         assertEquals("Test Subject", createdAnswer.getCreatedBy());
+        assertThat(createdAnswer.getCreated())
+            .isNotNull();
+        assertThat(createdAnswer.getCreated().getZone())
+            .isEqualTo(ZoneId.systemDefault());
     }
 
     @Test
@@ -528,6 +533,8 @@ public class AnswerResourceTest {
     private static Answer createAnswer( String answerBody) {
         Answer answer = new Answer();
         answer.setAnswer(answerBody);
+        assertThat(answer.getCreated())
+            .isNull();
         return answer;
     }
 


### PR DESCRIPTION
Expose createdAt as ZonedDateTime in order for the ui to be able to show time in user's timezone.
Ideally, we should have support for getting ZonedDateTime directly from the db, but in the meanwhile, we need to assume that persisted timestampz are in the server's timezone.