### PR TITLE
Query encoding

### DIFF
--- a/ui/src/components/questions/tags.js
+++ b/ui/src/components/questions/tags.js
@@ -7,7 +7,8 @@ class Tags extends React.Component {
     }
 
     clickTag(tag) {
-        this.props.history.push(`/search/[${tag.label}]`);
+        const encodedLabel = encodeURIComponent(`#${tag.label}`);
+        this.props.history.push(`/search/${encodedLabel}`);
     }
 
     renderTags() {

--- a/ui/src/views/search.view.js
+++ b/ui/src/views/search.view.js
@@ -10,22 +10,26 @@ class SearchView extends React.Component {
     constructor(props) {
         super(props);
 
-        let initSearchStr = '';
-
-        if (props.match.params.query) {
-            initSearchStr = props.match.params.query;
-        }
-
         this.state = {
             questions: [],
-            searchStr: initSearchStr,
+            searchStr: decodeURIComponent(props.match.params.query || ''),
             loadingSearch: false,
             searchResult: [],
             searched: false
         };
 
-        if (initSearchStr.length > 0) {
+        if (this.state.searchStr.length > 0) {
             this.search();
+        }
+    }
+
+    componentWillReceiveProps(nextProps) {
+        const { searchStr } = this.state;
+        const decodedQueryString = decodeURIComponent(nextProps.match.params.query || '');
+        if(decodedQueryString !== searchStr) {
+            this.setState({
+                searchStr: decodedQueryString
+            }, () => this.search());
         }
     }
 


### PR DESCRIPTION
The search view didn't properly encode the search parameter. Additionally clicking on tags in search result rows didn't lead to a new search so fixed that.